### PR TITLE
Feat: Add drive_init functions and one congig func

### DIFF
--- a/TMC5160.c
+++ b/TMC5160.c
@@ -34,3 +34,186 @@ HAL_StatusTypeDef TMC5160_ReadRegister(TMC5160_HandleTypeDef *htmc, TMC5160_Regs
 	  return result;
 }
 
+//  Configuration
+
+
+HAL_StatusTypeDef TMC5160_Configuration(TMC5160_HandleTypeDef *htmc){
+
+	uint8_t cmd_init[5][4]= {
+			{0x00, 0x01, 0x00, 0xC3},
+			{0x00, 0x06, 0x1F, 0x0A},
+			{0x00, 0x00, 0x00, 0x0A},
+			{0x00, 0x00, 0x00, 0x04},
+			{0x00, 0x00, 0x01, 0xF4},
+	};
+	// Костыль, который отправляет первую посылку данных, так как первая  посылка с одного раза не отправляется
+	HAL_StatusTypeDef result = TMC5160_WriteRegister(htmc, CHOPCONF, cmd_init[0]);
+
+	if(result != HAL_OK){
+				return result;
+		}
+
+	result = TMC5160_WriteRegister(htmc, CHOPCONF, cmd_init[0]);
+
+	if(result != HAL_OK){
+			return result;
+	}
+
+	result = TMC5160_WriteRegister(htmc, IHOLD_IRUN, cmd_init[1]);
+
+	if(result != HAL_OK){
+				return result;
+	}
+
+	result = TMC5160_WriteRegister(htmc, TPOWERDOWN, cmd_init[2]);
+
+	if(result != HAL_OK){
+		return result;
+	}
+
+	result = TMC5160_WriteRegister(htmc, GCONF, cmd_init[3]);
+
+	if(result != HAL_OK){
+				return result;
+	}
+
+	result = TMC5160_WriteRegister(htmc,  TPWMTHRS, cmd_init[4]);
+
+	if(result != HAL_OK){
+				return result;
+	}
+	return result ;
+}
+
+
+
+// Transform data
+void  divide_uint32_t(uint32_t value, uint8_t *data){
+    data[0]  = (uint8_t)(value >> 24);
+    data[1]  = (uint8_t)(value >> 16);
+    data[2]  = (uint8_t)(value >> 8);
+    data[3]  = (uint8_t)(value >> 0);
+}
+
+// Drive functions
+HAL_StatusTypeDef TMC5160_setFirstAcceleration(TMC5160_HandleTypeDef *htmc, uint16_t value){
+if((value > TMC5160_FIRST_ACCELERATION_LIMIT) || (value < 0) ){
+		return HAL_ERROR;
+	}
+	divide_uint32_t(value, htmc->first_acceleration);
+	return HAL_OK;
+}
+
+
+HAL_StatusTypeDef TMC5160_setMaxAcceleration(TMC5160_HandleTypeDef *htmc, uint16_t value){
+  if((value > TMC5160_MAX_ACCELERATION_LIMIT) || (value < 0) ){
+		return HAL_ERROR;
+	}
+
+	divide_uint32_t(value, htmc->max_acceleration );
+	return HAL_OK;
+}
+//
+HAL_StatusTypeDef TMC5160_setMaxDeceleration(TMC5160_HandleTypeDef *htmc, uint16_t value){
+  if((value > TMC5160_MAX_DECELERATION_LIMIT) || (value < 0) ){
+		return HAL_ERROR;
+	}
+	divide_uint32_t(value, htmc->max_deceleration  );
+	return HAL_OK;
+}
+
+HAL_StatusTypeDef TMC5160_setSecondDeceleration(TMC5160_HandleTypeDef *htmc, uint16_t value){
+  if((value > TMC5160_SECOND_DECELERATION_LIMIT) || (value < 0) ){
+		return HAL_ERROR;
+	}
+	divide_uint32_t(value, htmc->second_deceleration);
+	return HAL_OK;
+}
+
+HAL_StatusTypeDef TMC5160_setStopVelocity(TMC5160_HandleTypeDef *htmc, uint32_t value){
+  if((value > TMC5160_STOP_VELOCITY_LIMIT) || (value < 0) ){
+		return HAL_ERROR;
+	}
+	divide_uint32_t(value, htmc->stop_speed);
+	return HAL_OK;
+}
+
+HAL_StatusTypeDef TMC5160_setFirstVelocity(TMC5160_HandleTypeDef *htmc, uint32_t value){
+  if((value > TMC5160_FIRST_VELOCITY_LIMIT) || (value < 0) ){
+		return HAL_ERROR;
+	}
+	divide_uint32_t(value, htmc->first_speed);
+	return HAL_OK;
+}
+
+HAL_StatusTypeDef TMC5160_setMaxVelocity(TMC5160_HandleTypeDef *htmc, uint32_t value){
+  if((value > TMC5160_MAX_VELOCITY_LIMIT) || (value < 0) ){
+		return HAL_ERROR;
+	}
+	divide_uint32_t(value, htmc->max_speed);
+	return HAL_OK;
+}
+
+HAL_StatusTypeDef TMC5160_setRampMode(TMC5160_HandleTypeDef *htmc, RampModes mode){
+ 	divide_uint32_t(mode, htmc->ramp_mode);
+	return HAL_OK;
+}
+// Configuration Drive
+HAL_StatusTypeDef TMC5160_Configuration_Drive(TMC5160_HandleTypeDef *htmc){
+	TMC5160_setFirstAcceleration(htmc,1000);
+	TMC5160_setFirstVelocity(htmc,50000);
+	TMC5160_setMaxAcceleration(htmc,500);
+	TMC5160_setMaxVelocity(htmc,200000);
+	TMC5160_setMaxDeceleration(htmc,700);
+	TMC5160_setSecondDeceleration(htmc,1400);
+	TMC5160_setStopVelocity(htmc,10);
+	TMC5160_setRampMode(htmc, Positioning);
+	return HAL_OK;
+}
+
+// Default Configurations
+HAL_StatusTypeDef TMC5160_default_init(TMC5160_HandleTypeDef *htmc){
+
+	HAL_StatusTypeDef result  =   TMC5160_Configuration_Drive(htmc);
+	if(result != HAL_OK){
+				return result;
+			}
+	result = TMC5160_Configuration(htmc);
+	if(result != HAL_OK){
+			return result;
+		}
+	result = TMC5160_WriteRegister(htmc, A1, htmc->first_acceleration);
+	if(result != HAL_OK){
+				return result;
+			}
+	result = TMC5160_WriteRegister(htmc, V1, htmc->first_speed);
+	if(result != HAL_OK){
+				return result;
+			}
+	result = TMC5160_WriteRegister(htmc, AMAX, htmc->max_acceleration);
+	if(result != HAL_OK){
+				return result;
+			}
+	result = TMC5160_WriteRegister(htmc, VMAX, htmc->max_speed);
+	if(result != HAL_OK){
+				return result;
+			}
+	result = TMC5160_WriteRegister(htmc, DMAX, htmc->max_deceleration);
+	if(result != HAL_OK){
+				return result;
+			}
+	result = TMC5160_WriteRegister(htmc, D1, htmc->second_deceleration);
+	if(result != HAL_OK){
+				return result;
+			}
+	result = TMC5160_WriteRegister(htmc, VSTOP, htmc->stop_speed);
+	if(result != HAL_OK){
+				return result;
+			}
+	result = TMC5160_WriteRegister(htmc, RAMPMODE, htmc->ramp_mode);
+	if(result != HAL_OK){
+				return result;
+			}
+	return HAL_OK;
+}
+

--- a/TMC5160.c
+++ b/TMC5160.c
@@ -39,7 +39,7 @@ HAL_StatusTypeDef TMC5160_ReadRegister(TMC5160_HandleTypeDef *htmc, TMC5160_Regs
 
 HAL_StatusTypeDef TMC5160_Configuration(TMC5160_HandleTypeDef *htmc){
 
-	uint8_t cmd_init[5][4]= {
+	uint8_t cmd_init[5][4] = {
 			{0x00, 0x01, 0x00, 0xC3},
 			{0x00, 0x06, 0x1F, 0x0A},
 			{0x00, 0x00, 0x00, 0x0A},
@@ -215,5 +215,57 @@ HAL_StatusTypeDef TMC5160_default_init(TMC5160_HandleTypeDef *htmc){
 				return result;
 			}
 	return HAL_OK;
+}
+
+
+// New config function
+// Drive functions
+HAL_StatusTypeDef TMC5160_Conguration(TMC5160_HandleTypeDef *htmc){
+
+	uint8_t cmd_init[5][4] = {
+			{0x00, 0x01, 0x00, 0xC3},
+			{0x00, 0x06, 0x1F, 0x0A},
+			{0x00, 0x00, 0x00, 0x0A},
+			{0x00, 0x00, 0x00, 0x04},
+			{0x00, 0x00, 0x01, 0xF4},
+	};
+
+	// Костыль, который отправляет первую посылку данных, так как первая  посылка с одного раза не отправляется
+	HAL_StatusTypeDef result = TMC5160_WriteRegister(htmc, CHOPCONF, cmd_init[0]);
+
+	if(result != HAL_OK){
+				return result;
+		}
+
+	result = TMC5160_WriteRegister(htmc, CHOPCONF, cmd_init[0]);
+
+	if(result != HAL_OK){
+			return result;
+	}
+
+	result = TMC5160_WriteRegister(htmc, IHOLD_IRUN, cmd_init[1]);
+
+	if(result != HAL_OK){
+				return result;
+	}
+
+	result = TMC5160_WriteRegister(htmc, TPOWERDOWN, cmd_init[2]);
+
+	if(result != HAL_OK){
+		return result;
+	}
+
+	result = TMC5160_WriteRegister(htmc, GCONF, cmd_init[3]);
+
+	if(result != HAL_OK){
+				return result;
+	}
+
+	result = TMC5160_WriteRegister(htmc,  TPWMTHRS, cmd_init[4]);
+
+	if(result != HAL_OK){
+				return result;
+	}
+	return result ;
 }
 

--- a/TMC5160.h
+++ b/TMC5160.h
@@ -96,10 +96,37 @@ typedef enum  {
 
 // Struct
 typedef struct{
+			//Configuration Acceleration and velocity
+		uint8_t CHOPCONF[4];
+		uint8_t IHOLD_IRUN[4];
+		uint8_t DRV_STATUS[4];
+		uint8_t TPOWER_DOWN[4];
+		uint8_t TSTEP[4];
+		uint8_t TPWMTHRS[4];
+		uint8_t TCOOLTHRS[4];
+		uint8_t THIGH[4];
+		uint8_t GCONF[4];
+		uint8_t GLOBALSCALER[4];
+
+}TMC5160_RegisterOfConfiguration_HandleTypeDef;
+
+typedef struct{
+	//Configuration Acceleration and velocity
+		uint8_t max_speed[4];
+		uint8_t stop_speed[4];
+		uint8_t first_speed[4];
+		uint8_t first_acceleration[4];
+		uint8_t max_deceleration[4];
+		uint8_t second_deceleration[4];
+		uint8_t max_acceleration[4];
+		uint8_t ramp_mode[4];
+}TMC5160_ConfigurationOfVelosity_HandleTypeDef;
+
+typedef struct{
 		SPI_HandleTypeDef        *spi;
 		GPIO_TypeDef           *GPIOx;
 		uint16_t				   CS;
-
+		TMC5160_RegisterOfConfiguration_HandleTypeDef configuration;
 		//Configuration Acceleration and velocity
 		uint8_t max_speed[4];
 		uint8_t stop_speed[4];
@@ -129,4 +156,5 @@ HAL_StatusTypeDef TMC5160_setRampMode(TMC5160_HandleTypeDef *htmc, RampModes mod
 // Configuration Drive
 HAL_StatusTypeDef TMC5160_Configuration_Drive(TMC5160_HandleTypeDef *htmc);
 HAL_StatusTypeDef TMC5160_default_init(TMC5160_HandleTypeDef *htmc);
+
 #endif /* LIBS_TMC5160_STM32_HAL_TMC5160_STM32_HAL_H_ */

--- a/TMC5160.h
+++ b/TMC5160.h
@@ -9,6 +9,17 @@
 #define LIBS_TMC5160_STM32_HAL_TMC5160_STM32_HAL_H_
 #include "main.h"
 
+// Filter setting macros
+#define TMC5160_FIRST_ACCELERATION_LIMIT     0xFFFF // 2^16 - 1
+#define TMC5160_FIRST_VELOCITY_LIMIT         0xFFFFF  // 2^20 - 1
+#define TMC5160_MAX_ACCELERATION_LIMIT       0xFFFF // 2^16 - 1
+/*Attention for BELOW: Do not set 0 in positioning mode, even if V1=0!*/
+#define TMC5160_SECOND_DECELERATION_LIMIT    0xFFFF  // 2^16 - 1
+#define TMC5160_MAX_DECELERATION_LIMIT       0xFFFF  // 2^16 - 1
+/*Attention BELOW: Do not set 0 in positioning mode, minimum 10 recommend!*/
+#define TMC5160_STOP_VELOCITY_LIMIT          0x3FFFF  // 2^18 - 1
+#define TMC5160_MAX_VELOCITY_LIMIT           8388096  // 2^23 - 512
+
 
 // Registers
 typedef enum{
@@ -71,16 +82,51 @@ typedef enum{
 	LOST_STEPS		= 0x73, // R
 }TMC5160_Regs;
 
-// Structs
+// RampMode
+typedef enum  {
+	/* using all A, D and V parameters */
+	Positioning = 0,
+	/* Velocity mode to positive VMAX (using AMAX acceleration) */
+	VelocityPositive = 1,
+	/* Velocity mode to negative VMAX (using AMAX acceleration) */
+	VelocityNegative = 2,
+	/* velocity remains unchanged, unless stop event occurs */
+	Hold = 3,
+	} RampModes;
+
+// Struct
 typedef struct{
 		SPI_HandleTypeDef        *spi;
 		GPIO_TypeDef           *GPIOx;
 		uint16_t				   CS;
+
+		//Configuration Acceleration and velocity
+		uint8_t max_speed[4];
+		uint8_t stop_speed[4];
+		uint8_t first_speed[4];
+		uint8_t first_acceleration[4];
+		uint8_t max_deceleration[4];
+		uint8_t second_deceleration[4];
+		uint8_t max_acceleration[4];
+		uint8_t ramp_mode[4];
 }TMC5160_HandleTypeDef;
 
-// Prototipes Functions
+// Prototypes Functions
 HAL_StatusTypeDef TMC5160_WriteRegister(TMC5160_HandleTypeDef *htmc, TMC5160_Regs reg_addr, uint8_t data[]);
 HAL_StatusTypeDef TMC5160_ReadRegister(TMC5160_HandleTypeDef *htmc, TMC5160_Regs reg_addr, uint8_t data[]);
+HAL_StatusTypeDef TMC5160_Configuration(TMC5160_HandleTypeDef *htmc);
+// Configuration  function of theVelocity  ad  Acceleration
+HAL_StatusTypeDef TMC5160_setFirstAcceleration(TMC5160_HandleTypeDef *htmc, uint16_t value);
+HAL_StatusTypeDef TMC5160_setMaxAcceleration(TMC5160_HandleTypeDef *htmc, uint16_t value);
+//
+HAL_StatusTypeDef TMC5160_setMaxDeceleration(TMC5160_HandleTypeDef *htmc, uint16_t value);
+HAL_StatusTypeDef TMC5160_setSecondDeceleration(TMC5160_HandleTypeDef *htmc, uint16_t value);
+HAL_StatusTypeDef TMC5160_setStopVelocity(TMC5160_HandleTypeDef *htmc, uint32_t value);
+HAL_StatusTypeDef TMC5160_setFirstVelocity(TMC5160_HandleTypeDef *htmc, uint32_t value);
+HAL_StatusTypeDef TMC5160_setMaxVelocity(TMC5160_HandleTypeDef *htmc, uint32_t value);
+HAL_StatusTypeDef TMC5160_setRampMode(TMC5160_HandleTypeDef *htmc, RampModes mode);
 
-
+// Configuration Drive
+HAL_StatusTypeDef TMC5160_Configuration_Drive(TMC5160_HandleTypeDef *htmc);
+HAL_StatusTypeDef TMC5160_default_init(TMC5160_HandleTypeDef *htmc);
 #endif /* LIBS_TMC5160_STM32_HAL_TMC5160_STM32_HAL_H_ */


### PR DESCRIPTION
Add functions of the configuration different velocities and accelerations, default initialization,  that  inlude all configuration functions; function of dividing the uint32_t to uint8_t array.